### PR TITLE
chore: restrict node version to `<15`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
     "webpack-dev-server": "^3.9.0",
     "webpack-node-externals": "^1.7.2"
   },
+  "engines": {
+    "node": "<15"
+  },
   "author": "0xTsukino",
   "license": "ISC"
 }


### PR DESCRIPTION
I run into Sass build issues when running `yarn dev-ui` with node lts:
```
Error: Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime (93)
For more information on which environments are supported please see:
https://github.com/sass/node-sass/releases/tag/v4.14.1
```

As per the referred [GH issue](https://github.com/sass/node-sass/releases/tag/v4.14.1), it looks like one must use a node version lower than `15`.

So this PR enforces that.

### Test plan
- on `main`
  - use a node version >= 15  
  - `yarn dev-ui`
  - you'll see the error mentionned above
- on this branch:
  - node version >=15: you should see a warning informing you to use a lower version
  - node version < 15: you can run `yarn dev-ui` 