### PR TITLE
fix:lang: refer to `APP_TITLE` in twitter acount association screen

### DIFF
--- a/src/pages/ConnectTwitterView/index.tsx
+++ b/src/pages/ConnectTwitterView/index.tsx
@@ -309,7 +309,7 @@ function VerifyView(props: {
         <div className="text-xl font-semibold">Make a verification tweet</div>
       </div>
       <div className="my-4 text-center">
-        {`Associate your Austism profile with ${twitterAuth?.username} by making a tweet!`}
+        {`Associate your ${process.env.APP_TITLE} profile with ${twitterAuth?.username} by making a tweet!`}
       </div>
       <div className="my-4">
         <div className="border rounded-xl m-4 p-4 flex flex-row flex-nowrap">

--- a/webpack.ui.config.js
+++ b/webpack.ui.config.js
@@ -20,7 +20,7 @@ const envPlugin = new webpack.EnvironmentPlugin({
   ARB_REGISTRAR: '',
   ARB_EXPLORER: '',
   GUN_PEERS: [],
-  APP_TITLE: '',
+  APP_TITLE: 'Zkitter',
   APP_LOGO: '',
 });
 


### PR DESCRIPTION
Closes #45 

Fix copy in twitter account association screen.

|screenshot|
|---|
|![image](https://user-images.githubusercontent.com/38692952/197067173-8e9a10ec-cfa8-4f45-8ea7-d8280117dde7.png)|

### Test Plan
I proceeded like follows to test the fix:
1. hack `<ConnectTwitterView />`:
  ```diff
  diff --git a/src/pages/ConnectTwitterView/index.tsx b/src/pages/ConnectTwitterView/index.tsx
  index 724c319..af9d5d8 100644
  --- a/src/pages/ConnectTwitterView/index.tsx
  +++ b/src/pages/ConnectTwitterView/index.tsx
  @@ -75,6 +75,7 @@ export default function ConnectTwitterView(props: Props): ReactElement {
           console.error(e);
         } finally {
           setFetching(false);
  +        setViewType(ViewType.verify);
         }
       })();
     }, [selected]);
  ```
2. Go to `http://localhost:8080/connect/twitter`
