### PR TITLE
fix: redirect to home page when clicking on zkitter logo in top nav

### DIFF
--- a/src/components/TopNav/HomeLogo.tsx
+++ b/src/components/TopNav/HomeLogo.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Icon from '../Icon';
+
+const HomeLogo = () => (
+    <Link to="/explore">
+        <Icon url="/applogo.svg" size={2} />
+    </Link>
+);
+
+export default HomeLogo

--- a/src/components/TopNav/HomeLogo.tsx
+++ b/src/components/TopNav/HomeLogo.tsx
@@ -3,9 +3,9 @@ import { Link } from 'react-router-dom';
 import Icon from '../Icon';
 
 const HomeLogo = () => (
-    <Link to="/explore">
-        <Icon url="/applogo.svg" size={2} />
-    </Link>
+  <Link to="/explore">
+    <Icon url="/applogo.svg" size={2} />
+  </Link>
 );
 
-export default HomeLogo
+export default HomeLogo;

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -17,6 +17,7 @@ import { useThemeContext } from '../ThemeContext';
 import NotificationIcon from '../NotificationIcon';
 import ChatNavIcon from '../ChatNavIcon';
 import GlobalSearchInput from '../GlobalSearchInput';
+import HomeLogo from "@components/TopNav/HomeLogo";
 
 export default function TopNav(): ReactElement {
   const theme = useThemeContext();
@@ -135,7 +136,7 @@ function DefaultHeaderGroup() {
         'flex flex-row flex-nowrap items-center flex-shrink-0',
         'p-1 mx-4 overflow-hidden'
       )}>
-      <Icon url="/applogo.svg" size={2} />
+      <HomeLogo />
     </div>
   );
 }
@@ -153,6 +154,7 @@ function SearchHeaderGroup() {
     if (history.action !== 'POP') return history.goBack();
     history.push('/');
   }, [history]);
+
 
   let address = '';
 
@@ -209,7 +211,7 @@ function GlobalHeaderGroup() {
         'flex flex-row flex-nowrap flex-grow items-center flex-shrink-0',
         'p-1 mx-4 overflow-hidden'
       )}>
-      <Icon url="/applogo.svg" size={2} />
+      <HomeLogo />
       <TopNavContextButton />
     </div>
   );

--- a/src/components/TopNav/index.tsx
+++ b/src/components/TopNav/index.tsx
@@ -17,7 +17,7 @@ import { useThemeContext } from '../ThemeContext';
 import NotificationIcon from '../NotificationIcon';
 import ChatNavIcon from '../ChatNavIcon';
 import GlobalSearchInput from '../GlobalSearchInput';
-import HomeLogo from "@components/TopNav/HomeLogo";
+import HomeLogo from '@components/TopNav/HomeLogo';
 
 export default function TopNav(): ReactElement {
   const theme = useThemeContext();
@@ -154,7 +154,6 @@ function SearchHeaderGroup() {
     if (history.action !== 'POP') return history.goBack();
     history.push('/');
   }, [history]);
-
 
   let address = '';
 


### PR DESCRIPTION
Fixes #92 

Wrap zkitter logo into a `Link` in order to always redirect to `/explore` when clicking it.